### PR TITLE
make pandas optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,26 @@ At a high level, the library consists of three parts:
 2. A `MappingProgram` class that can be used to execute a "program" of mapping rules against either "records" or Pandas dataframes.
 3. Code for interacting with the Flatfile mapping API to get AI-suggested sets of mapping rules for a given source and target schema.
 
+# Installation
+
+By default the library does not include the code for using pandas, because pandas and numpy are both large dependencies.
+
+So if you do
+
+```bash
+pip install flatfile-mapping
+```
+
+you will not get pandas installed and the parts of the code for interacting with dataframes won't work.
+
+If you do
+
+```bash
+pip install flatfile-mapping[pandas]
+```
+
+then you will get pandas and numpy dependencies installed and you can use those features.
+
 # Mapping Rules
 
 The mapping rules are defined using a domain-specific language (DSL) defined in the `flatfile_mapping.mapping_rule` module.
@@ -465,6 +485,8 @@ Which will result in the following records:
 
 ## Applied to Dataframes
 
+**For this part you must have installed the library with the `[pandas]` extra.**
+
 ```python
 import pandas as pd
 
@@ -543,9 +565,3 @@ will suggest more types of rules.
 By default it only suggests matches that have a similarity score of 0.5 or higher.
 This is probably the value you want, but you can specify a different threshhold
 by providing a `mapping_confidence_threshold` argument to `get_mapping_rules`.
-
-# Installation
-
-```bash
-pip install flatfile-mapping
-```

--- a/pdm.lock
+++ b/pdm.lock
@@ -2,10 +2,10 @@
 # It is not intended for manual editing.
 
 [metadata]
-groups = ["default", "pytest", "test"]
+groups = ["default", "test", "pandas"]
 strategy = ["cross_platform"]
 lock_version = "4.4"
-content_hash = "sha256:50a8a160995dfebe7cf028244e45edee17056c396e9d1dd1d333eb10507063d7"
+content_hash = "sha256:c723136ffededdb8502d5369eb4609d6e7b4b34ded898aad83025fcf8315c8c5"
 
 [[package]]
 name = "annotated-types"
@@ -729,6 +729,19 @@ summary = "Typing stubs for pytz"
 files = [
     {file = "types-pytz-2023.3.1.1.tar.gz", hash = "sha256:cc23d0192cd49c8f6bba44ee0c81e4586a8f30204970fc0894d209a6b08dab9a"},
     {file = "types_pytz-2023.3.1.1-py3-none-any.whl", hash = "sha256:1999a123a3dc0e39a2ef6d19f3f8584211de9e6a77fe7a0259f04a524e90a5cf"},
+]
+
+[[package]]
+name = "types-requests"
+version = "2.31.0.10"
+requires_python = ">=3.7"
+summary = "Typing stubs for requests"
+dependencies = [
+    "urllib3>=2",
+]
+files = [
+    {file = "types-requests-2.31.0.10.tar.gz", hash = "sha256:dc5852a76f1eaf60eafa81a2e50aefa3d1f015c34cf0cba130930866b1b22a92"},
+    {file = "types_requests-2.31.0.10-py3-none-any.whl", hash = "sha256:b32b9a86beffa876c0c3ac99a4cd3b8b51e973fb8e3bd4e0a6bb32c7efad80fc"},
 ]
 
 [[package]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,12 +1,11 @@
 [project]
 name = "flatfile-mapping"
-version = "0.1.1"
+version = "0.1.2.2"
 description = ""
 authors = [
     {name = "Joel Grus", email = "joel@flatfile.io"},
 ]
 dependencies = [
-    "pandas>=2.0.3",
     "pydantic>=2.4.2",
     "sympy>=1.12",
     "lark>=1.1.8",
@@ -16,6 +15,12 @@ requires-python = ">=3.8"
 readme = "README.md"
 license = {text = "MIT"}
 repository = "https://github.com/flatfilers/flatfile-mapping"
+
+[project.optional-dependencies]
+pandas = [
+    "pandas>=2.0.3",
+    "pandas-stubs>=2.0.2.230605",
+]
 
 [build-system]
 requires = ["pdm-backend"]
@@ -30,4 +35,5 @@ test = [
     "coverage>=7.3.2",
     "pytest>=7.4.3",
     "requests-mock>=1.11.0",
+    "types-requests>=2.31.0.10",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "flatfile-mapping"
-version = "0.1.2.2"
+version = "0.1.3"
 description = ""
 authors = [
     {name = "Joel Grus", email = "joel@flatfile.io"},

--- a/src/flatfile_mapping/__init__.py
+++ b/src/flatfile_mapping/__init__.py
@@ -1,14 +1,15 @@
 """
 Flatfile Mapping in Python
 """
-__version__ = "0.1.1"
+__version__ = "0.1.2.2"
 
-from flatfile_mapping.mapping_rule import parse, MappingRule
+from flatfile_mapping.mapping_rule import parse, MappingRule, Row
 from flatfile_mapping.mapping_program import MappingProgram
 
 __all__ = [
     "MappingRule",
     "MappingProgram",
+    "Row",
     # parse a JSON representation into a typed mapping rule object
     "parse",
 ]

--- a/src/flatfile_mapping/__init__.py
+++ b/src/flatfile_mapping/__init__.py
@@ -1,7 +1,7 @@
 """
 Flatfile Mapping in Python
 """
-__version__ = "0.1.2.2"
+__version__ = "0.1.3"
 
 from flatfile_mapping.mapping_rule import parse, MappingRule, Row
 from flatfile_mapping.mapping_program import MappingProgram

--- a/src/flatfile_mapping/automapping.py
+++ b/src/flatfile_mapping/automapping.py
@@ -7,7 +7,7 @@ from flatfile_mapping.mapping_rule import MappingRule, parse
 
 __all__ = ["get_mapping_rules"]
 
-API_BASE_URL = os.environ.get("FLATFILE_API_BASE_URL", "https://api.x.flatfile.com/v1/")
+API_BASE_URL = os.environ.get("FLATFILE_API_BASE_URL", "https://api.x.flatfile.com/v1")
 
 
 def get_mapping_rules(

--- a/src/flatfile_mapping/filter.py
+++ b/src/flatfile_mapping/filter.py
@@ -2,18 +2,20 @@
 This file contains the implementation of filtering logic.
 You should not need to use anything here directly.
 """
-
+from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import List, Union, Any
+from typing import List, Union, Any, TYPE_CHECKING, Sequence
 import re
 
 from lark import Lark, ParseTree, lexer, Tree, Token
-import pandas as pd
+
+if TYPE_CHECKING:
+    import pandas as pd
 
 from flatfile_mapping.mapping_rule import Row
 
-__all__ = []
+__all__: Sequence[str] = []
 
 
 def as_number(s: Any) -> Union[int, float, None]:
@@ -196,15 +198,19 @@ class Filter:
         return self.filter(record)
 
     def satisfies_df(
-        self, source: pd.DataFrame, destination: pd.DataFrame
-    ) -> pd.Series:
+        self, source: "pd.DataFrame", destination: "pd.DataFrame"
+    ) -> "pd.Series":
+        try:
+            import pandas as pd
+        except ImportError:
+            raise RuntimeError("pandas is not installed")
         df = pd.concat([source, destination.add_prefix("destination!")], axis=1)
         return _filter_df(df, self._root)
 
     def filter(self, row: Row) -> bool:
         return _filter(row, self._root)
 
-    def filter_df(self, df: pd.DataFrame) -> pd.DataFrame:
+    def filter_df(self, df: "pd.DataFrame") -> "pd.DataFrame":
         return df[_filter_df(df, self._root)]
 
 
@@ -305,7 +311,12 @@ def _filter(row: Row, node: Node) -> bool:
     raise ValueError(f"Unknown value {value}")
 
 
-def _filter_df(df: pd.DataFrame, node: Node) -> pd.Series:
+def _filter_df(df: "pd.DataFrame", node: Node) -> "pd.Series":
+    try:
+        import pandas as pd
+    except ImportError:
+        raise RuntimeError("pandas is not installed")
+
     value = node.value
     children = node.children
 

--- a/tests/filter_test.py
+++ b/tests/filter_test.py
@@ -1,7 +1,13 @@
 from typing import List
 
-import pandas as pd
-from pandas.testing import assert_frame_equal
+try:
+    import pandas as pd
+    from pandas.testing import assert_frame_equal
+except ImportError:
+    pd = None
+    assert_frame_equal = None
+
+import pytest
 
 from flatfile_mapping.mapping_rule import Row
 from flatfile_mapping.filter import Filter
@@ -14,8 +20,11 @@ records: List[Row] = [
 
 destination_records: List[Row] = [{"output": 1}, {"output": 2}, {"output": 3}]
 
-df = pd.DataFrame(records)
-destination_df = pd.DataFrame(destination_records)
+if pd is not None:
+    df = pd.DataFrame(records)
+    destination_df = pd.DataFrame(destination_records)
+else:
+    df = destination_df = None
 
 
 class TestRecords:
@@ -108,6 +117,7 @@ class TestRecords:
         assert filtered == records[1:2]
 
 
+@pytest.mark.skipif(pd is None, reason="pandas is not installed")
 class TestDataFrame:
     def test_simple(self):
         filter = Filter.from_query("name eq John")

--- a/tests/mapping_program_pandas_test.py
+++ b/tests/mapping_program_pandas_test.py
@@ -1,8 +1,12 @@
 from copy import deepcopy
 from typing import List
 
-import pandas as pd
-from pandas.testing import assert_frame_equal
+try:
+    import pandas as pd
+    from pandas.testing import assert_frame_equal
+except ImportError:
+    pd = None
+    assert_frame_equal = None
 import pytest
 
 
@@ -13,19 +17,23 @@ def expect_source_fields(program: MappingProgram, expected: List[str]):
     assert sorted(program.source_fields()) == sorted(expected)
 
 
-def assert_equal(df1: pd.DataFrame, df2: pd.DataFrame) -> None:
+def assert_equal(df1: "pd.DataFrame", df2: "pd.DataFrame") -> None:
     assert_frame_equal(df1, df2, check_dtype=False, check_like=True)
 
 
-records = pd.DataFrame(
-    [
-        {"name": "Dave", "age": 42, "location": "San Francisco"},
-        {"name": "Bob", "age": 32, "location": "San Francisco"},
-        {"name": "Alice", "age": 22, "location": "New York"},
-    ]
-)
+if pd is not None:
+    records = pd.DataFrame(
+        [
+            {"name": "Dave", "age": 42, "location": "San Francisco"},
+            {"name": "Bob", "age": 32, "location": "San Francisco"},
+            {"name": "Alice", "age": 22, "location": "New York"},
+        ]
+    )
+else:
+    records = []
 
 
+@pytest.mark.skipif(pd is None, reason="pandas is not installed")
 def test_simple_assign_program():
     program = MappingProgram.from_json(
         [
@@ -67,6 +75,7 @@ def test_simple_assign_program():
     )
 
 
+@pytest.mark.skipif(pd is None, reason="pandas is not installed")
 def test_simple_assign_program_with_find_replace():
     program = MappingProgram.from_json(
         [
@@ -116,6 +125,7 @@ def test_simple_assign_program_with_find_replace():
     )
 
 
+@pytest.mark.skipif(pd is None, reason="pandas is not installed")
 def test_concatenate():
     program = MappingProgram.from_json(
         [
@@ -166,6 +176,7 @@ def test_concatenate():
     )
 
 
+@pytest.mark.skipif(pd is None, reason="pandas is not installed")
 def test_array():
     program = MappingProgram.from_json(
         [
@@ -207,6 +218,7 @@ def test_array():
     )
 
 
+@pytest.mark.skipif(pd is None, reason="pandas is not installed")
 def test_respects_ffql_filters():
     program = MappingProgram.from_json(
         [
@@ -250,6 +262,7 @@ def test_respects_ffql_filters():
     )
 
 
+@pytest.mark.skipif(pd is None, reason="pandas is not installed")
 def test_respects_ffql_filters_on_destination_fields():
     program = MappingProgram.from_json(
         [
@@ -293,6 +306,7 @@ def test_respects_ffql_filters_on_destination_fields():
     )
 
 
+@pytest.mark.skipif(pd is None, reason="pandas is not installed")
 def test_simple_transform_program():
     program = MappingProgram.from_json(
         [
@@ -335,6 +349,7 @@ def test_simple_transform_program():
     )
 
 
+@pytest.mark.skipif(pd is None, reason="pandas is not installed")
 def test_transform_to_source_fields():
     cloned_records = deepcopy(records)
 
@@ -368,6 +383,7 @@ def test_transform_to_source_fields():
     )
 
 
+@pytest.mark.skipif(pd is None, reason="pandas is not installed")
 def test_transform_on_destination_fields():
     program = MappingProgram.from_json(
         [
@@ -415,6 +431,7 @@ def test_transform_on_destination_fields():
     )
 
 
+@pytest.mark.skipif(pd is None, reason="pandas is not installed")
 def test_field_names_can_have_spaces_in_them():
     records = pd.DataFrame(
         [
@@ -470,6 +487,7 @@ def test_field_names_can_have_spaces_in_them():
     )
 
 
+@pytest.mark.skipif(pd is None, reason="pandas is not installed")
 def test_coalesce():
     records = pd.DataFrame(
         [
@@ -520,6 +538,7 @@ def test_coalesce():
     )
 
 
+@pytest.mark.skipif(pd is None, reason="pandas is not installed")
 def test_regex_extract_with_single_destination_field():
     regex = "^San (.*)$"
     program = MappingProgram.from_json(
@@ -571,6 +590,7 @@ def test_regex_extract_with_single_destination_field():
     )
 
 
+@pytest.mark.skipif(pd is None, reason="pandas is not installed")
 def test_regex_extract_with_multiple_destination_fields():
     program = MappingProgram.from_json(
         [
@@ -608,6 +628,7 @@ def test_regex_extract_with_multiple_destination_fields():
     )
 
 
+@pytest.mark.skipif(pd is None, reason="pandas is not installed")
 def test_interpolate():
     program = MappingProgram.from_json(
         [
@@ -642,6 +663,7 @@ def test_interpolate():
     )
 
 
+@pytest.mark.skipif(pd is None, reason="pandas is not installed")
 def test_interpolate_with_missing_fields():
     program = MappingProgram.from_json(
         [
@@ -676,6 +698,7 @@ def test_interpolate_with_missing_fields():
     )
 
 
+@pytest.mark.skipif(pd is None, reason="pandas is not installed")
 def test_arithmetic():
     program = MappingProgram.from_json(
         [
@@ -720,6 +743,7 @@ def test_arithmetic():
 
 # not sure what to do here
 @pytest.mark.skip
+@pytest.mark.skipif(pd is None, reason="pandas is not installed")
 def test_arithmetic_with_bad_equation():
     program = MappingProgram.from_json(
         [
@@ -755,6 +779,7 @@ def test_arithmetic_with_bad_equation():
     ]
 
 
+@pytest.mark.skipif(pd is None, reason="pandas is not installed")
 def test_delete_destination_fields():
     program = MappingProgram.from_json(
         [
@@ -800,6 +825,7 @@ def test_delete_destination_fields():
     )
 
 
+@pytest.mark.skipif(pd is None, reason="pandas is not installed")
 def test_subprograms():
     program = MappingProgram.from_json(
         [
@@ -869,6 +895,7 @@ def test_subprograms():
     )
 
 
+@pytest.mark.skipif(pd is None, reason="pandas is not installed")
 def test_simple_nesting():
     records = pd.DataFrame(
         [
@@ -934,6 +961,7 @@ def test_simple_nesting():
     )
 
 
+@pytest.mark.skipif(pd is None, reason="pandas is not installed")
 def test_complex_nesting_rules():
     records = pd.DataFrame(
         [


### PR DESCRIPTION
this ended up being slightly hairier than I expected but I have tested it manually and it seems to work

the idea is that pandas/numpy is an extremely heavyweight dependency if you're not actually going to use it, so I made it an extra. if you just want to map over records (and use the API) you don't have to install it.